### PR TITLE
Fixed a bug caused by YOLOv3

### DIFF
--- a/solver.go
+++ b/solver.go
@@ -70,7 +70,7 @@ func (s *YOLOSolver) Solve(category, object string, tasks []Task) []Task {
 		}
 
 		for _, detection := range detections {
-			fixedClassName := strings.Join(strings.Fields(detection.ClassName), "")
+			fixedClassName := strings.TrimSpace(detection.ClassName)
 			if fixedClassName == object && detection.Confidence > 0.6 {
 				s.Log.Debugf("Detected %v in provided image", object)
 

--- a/solver.go
+++ b/solver.go
@@ -1,6 +1,7 @@
 package hcaptcha
 
 import (
+	"strings"
 	"github.com/justtaldevelops/go-hcaptcha/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/wimspaargaren/yolov3"
@@ -69,7 +70,8 @@ func (s *YOLOSolver) Solve(category, object string, tasks []Task) []Task {
 		}
 
 		for _, detection := range detections {
-			if detection.ClassName == object && detection.Confidence > 0.6 {
+			fixedClassName := strings.Join(strings.Fields(detection.ClassName), "")
+			if fixedClassName == object && detection.Confidence > 0.6 {
 				s.Log.Debugf("Detected %v in provided image", object)
 
 				answers = append(answers, task)


### PR DESCRIPTION
Fixed a bug caused by YOLOv3 that would return a string even with empty characters, causing a problem in a comparison.
I got this problem using the latest version of YOLOv3, by doing this should fix the bug for everybody.

I'm new to GO, so if this can be done in a better way, please someone correct me.